### PR TITLE
Feature/image save

### DIFF
--- a/YourName/YourName/Sources/Domain Layer/Snapshot/SnapshotService.swift
+++ b/YourName/YourName/Sources/Domain Layer/Snapshot/SnapshotService.swift
@@ -23,7 +23,6 @@ enum YourNameSnapshotService: SnapshotService {
     
     static func captureToImage(_ scrollView: UIScrollView) -> UIImage? {
         // saved scrollView info
-        let savedFrame = scrollView.frame
         let savedOffset = scrollView.contentOffset
         let superview = scrollView.superview
         
@@ -34,19 +33,14 @@ enum YourNameSnapshotService: SnapshotService {
         let renderer = UIGraphicsImageRenderer(size: scrollView.contentSize)
         let image = renderer.image { [weak scrollView] context in
             guard let scrollView = scrollView else { return }
-            scrollView.frame = CGRect(x: 0, y: 0,
-                                      width: scrollView.contentSize.width,
-                                      height: scrollView.contentSize.height)
+            scrollView.frame = CGRect(origin: .zero, size: scrollView.contentSize)
             scrollView.layer.render(in: context.cgContext)
         }
         
         // add subview & configure scrollView
         superview?.addSubview(scrollView)
-        superview?.layoutIfNeeded()
         scrollView.snp.makeConstraints { $0.edges.equalToSuperview() }
-        scrollView.frame = savedFrame
         scrollView.contentOffset = savedOffset
-    
         return image
     }
 }

--- a/YourName/YourName/Sources/Domain Layer/Snapshot/SnapshotService.swift
+++ b/YourName/YourName/Sources/Domain Layer/Snapshot/SnapshotService.swift
@@ -30,17 +30,15 @@ enum YourNameSnapshotService: SnapshotService {
         // remove from superView
         scrollView.removeFromSuperview()
         
-        // capture
-        scrollView.contentOffset = .zero
-        let captureSize = CGSize(width: scrollView.contentSize.width,
-                                 height: scrollView.contentSize.height)
-     
-        UIGraphicsBeginImageContext(captureSize)
-        scrollView.frame = CGRect(x: 0, y: 0,
-                            width: captureSize.width,
-                            height: captureSize.height)
-        scrollView.layer.render(in: UIGraphicsGetCurrentContext()!)
-        let image = UIGraphicsGetImageFromCurrentImageContext()
+        // UIImage render
+        let renderer = UIGraphicsImageRenderer(size: scrollView.contentSize)
+        let image = renderer.image { [weak scrollView] context in
+            guard let scrollView = scrollView else { return }
+            scrollView.frame = CGRect(x: 0, y: 0,
+                                      width: scrollView.contentSize.width,
+                                      height: scrollView.contentSize.height)
+            scrollView.layer.render(in: context.cgContext)
+        }
         
         // add subview & configure scrollView
         superview?.addSubview(scrollView)
@@ -48,9 +46,7 @@ enum YourNameSnapshotService: SnapshotService {
         scrollView.snp.makeConstraints { $0.edges.equalToSuperview() }
         scrollView.frame = savedFrame
         scrollView.contentOffset = savedOffset
-        
-        // end
-        UIGraphicsEndImageContext()
+    
         return image
     }
 }

--- a/YourName/YourName/Sources/UI Layer/Screens/MyCardList/MySkillProgressView.swift
+++ b/YourName/YourName/Sources/UI Layer/Screens/MyCardList/MySkillProgressView.swift
@@ -20,22 +20,41 @@ final class MySkillProgressView: UIView, NibLoadable {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupFromNib()
-        configure(skillStackView: skillStackView)
+    }
+    
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.configure(skillStackView: skillStackView)
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         setupFromNib()
-        configure(skillStackView: skillStackView)
     }
     
     private func configure(skillStackView: UIStackView) {
         guard let firstView = skillStackView.subviews.first,
               let endView = skillStackView.subviews.last else { return }
-        firstView.cornerRadius = (self.bounds.height * 0.26) / 2
-        endView.cornerRadius = (self.bounds.height * 0.26) / 2
-        firstView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMinXMaxYCorner]
-        endView.layer.maskedCorners = [.layerMaxXMaxYCorner, .layerMaxXMinYCorner]
+        
+        let firstViewBezierPath = UIBezierPath(roundedRect: CGRect(origin: .zero, size: .init(width: (self.bounds.width / 10),
+                                                                               height: (self.bounds.height * 0.26))),
+                                byRoundingCorners: [.topLeft, .bottomLeft],
+                                cornerRadii: .init(width: (self.bounds.height * 0.26) / 2,
+                                                   height: (self.bounds.height * 0.26) / 2))
+        let endViewBezierPath = UIBezierPath(roundedRect: CGRect(origin: .zero, size: .init(width: (self.bounds.width / 10),
+                                                                                            height: (self.bounds.height * 0.26))),
+                                             byRoundingCorners: [.topRight, .bottomRight],
+                                             cornerRadii: .init(width: (self.bounds.height * 0.26) / 2,
+                                                                height: (self.bounds.height * 0.26) / 2))
+ 
+        firstView.layer.mask = setupRoundCornerLayer(path: firstViewBezierPath)
+        endView.layer.mask = self.setupRoundCornerLayer(path: endViewBezierPath)
+    }
+    
+    private func setupRoundCornerLayer(path: UIBezierPath) -> CAShapeLayer {
+        let maskedLayer = CAShapeLayer()
+        maskedLayer.path = path.cgPath
+        return maskedLayer
     }
     
     func configure(skill: MySkillProgressView.Item) {

--- a/YourName/YourName/Sources/UI Layer/Screens/NameCardDetail/NameCardDetailViewModel.swift
+++ b/YourName/YourName/Sources/UI Layer/Screens/NameCardDetail/NameCardDetailViewModel.swift
@@ -188,7 +188,7 @@ extension NameCardDetailViewModel: CardDetailMoreViewDelegate {
 
         let vc = UIActivityViewController(activityItems: [image], applicationActivities: nil)
         
-        activityViewController.accept(vc)
+        self.activityViewController.accept(vc)
         
         // Quest
         self.questRepository.updateQuest(.saveMeetuMyAlbum, to: .waitingDone)


### PR DESCRIPTION
- 이미지 저장시에 생기는 버그 수정했습니다.


imp: UIGraphicsImageRenderer API 사용으로 수정 

fix: image렌더시 기존에는 cornerRadius의 maskedCorners 가 적용되지않는 문제점을 파악함 (UIGraphicImageRenderer로 UIImage 객체로 render하는 과정에서만 4방향의 corner 모두에 masked가 씌워짐. render 하지않는 상황에서는 문제가 없음) 
-> 기존 디자인대로 양끝에만 radius가 layer에 mask될 수 있도록 수정

<기존>
<img width="289" alt="image" src="https://user-images.githubusercontent.com/42825223/148228307-e5fbcb50-9ef9-46e1-869b-33a3313630a4.png">

<수정>
<img width="274" alt="image" src="https://user-images.githubusercontent.com/42825223/148228370-af0121b2-ca41-4730-92dc-6d5100b19e02.png">
